### PR TITLE
chore(deps): bump hashicorp/google upper bound to < 7.19

### DIFF
--- a/_example/versions.tf
+++ b/_example/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.50, < 7.18"
+      version = ">= 3.50, < 7.19"
     }
   }
 }


### PR DESCRIPTION
## Summary
- clean replacement for Dependabot PR #24 to unblock CI flow
- update provider constraint in `_example/versions.tf` to `>= 3.50, < 7.19`
- no functional module logic changes

## Why this PR exists
Dependabot PRs in this repository cannot access required GCP auth secrets in current workflows, causing non-actionable CI failures.

## Scope
- dependency boundary update only
- no resource behavior changes

## Notes
- supersedes #24 for merge purposes
